### PR TITLE
GNOME runtime 41, FEDC support

### DIFF
--- a/re.sonny.Commit.yaml
+++ b/re.sonny.Commit.yaml
@@ -4,10 +4,10 @@ runtime-version: '41'
 sdk: org.gnome.Sdk
 command: re.sonny.Commit
 finish-args:
-  - '--share=ipc'
-  - '--socket=fallback-x11'
-  - '--socket=wayland'
-  - '--require-version=1.1.2'
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --require-version=1.1.2
 cleanup:
   - /include
   - /lib/pkgconfig
@@ -21,15 +21,19 @@ cleanup:
 modules:
   - name: gspell
     config-opts:
-      - '--disable-vala'
-      - '--disable-static'
-      - '--disable-gtk-doc'
+      - --disable-vala
+      - --disable-static
+      - --disable-gtk-doc
     sources:
       - type: archive
-        url: https://download-fallback.gnome.org/sources/gspell/1.9/gspell-1.9.1.tar.xz
-        sha256: dcbb769dfdde8e3c0a8ed3102ce7e661abbf7ddf85df08b29915e92cd723abdd
+        url: https://download.gnome.org/sources/gspell/1.8/gspell-1.8.4.tar.xz
+        sha256: cf4d16a716e813449bd631405dc1001ea89537b8cdae2b8abfb3999212bd43b4
+        x-checker-data:
+          type: gnome
+          name: gspell
     cleanup:
       - /bin
+
   - name: Commit
     buildsystem: meson
     sources:
@@ -37,3 +41,6 @@ modules:
         url: https://github.com/sonnyp/Commit.git
         tag: v2.2.0
         commit: 9aa928e3326485df7d5b890a13894264f169e73f
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$


### PR DESCRIPTION
Updated GNOME runtime to 41, added FEDC support (gspell has been downgraded because is not stable)