### PR TITLE
Update runtime to 50

### DIFF
--- a/re.sonny.Commit.json
+++ b/re.sonny.Commit.json
@@ -1,7 +1,7 @@
 {
   "id": "re.sonny.Commit",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "49",
+  "runtime-version": "50",
   "sdk": "org.gnome.Sdk",
   "command": "re.sonny.Commit",
   "finish-args": [
@@ -14,14 +14,7 @@
   "cleanup": [
     "/include",
     "/lib/pkgconfig",
-    "/man",
-    "/share/doc",
-    "/share/gtk-doc",
-    "/share/man",
-    "/share/pkgconfig",
-    "/share/installed-tests",
-    "*.la",
-    "*.a"
+    "/share/gir-1.0"
   ],
   "modules": [
     {


### PR DESCRIPTION
- Update the runtime version to 50
- Drop ineffective cleanup commands
- Improve cleanup commands to reduce the Flatpak size

Installed size reduced from 1.2 MB to 740 kB